### PR TITLE
Added support to read a message

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,8 @@ services:
         - DPS_SERVICE_NAME=crrp-notification-worker
     ports:
       - "5055:8080"
+    environment: 
+      - RABBITMQ_HOST=rabbitmq
     networks:
       - dps-net
 

--- a/src/crrp-notification-worker/pom.xml
+++ b/src/crrp-notification-worker/pom.xml
@@ -32,6 +32,17 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-amqp</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>ca.bc.gov.open</groupId>
+			<artifactId>dpsnotification</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 			<exclusions>
@@ -41,6 +52,7 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/crrp-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/crrp/notification/worker/Keys.java
+++ b/src/crrp-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/crrp/notification/worker/Keys.java
@@ -1,0 +1,17 @@
+package ca.bc.gov.open.pssg.rsbc.crrp.notification.worker;
+
+public class Keys {
+
+    private Keys() {}
+
+    public static final String CRRP_VALUE = "CRRP";
+
+    public static final String CRRP_QUEUE_NAME = CRRP_VALUE + "_queue";
+
+    /**
+     * DO NOT CHANGE - The default output notification value.
+     */
+    public static final String OUTPUT_NOTIFICATION_VALUE = "outputNotification";
+
+
+}

--- a/src/crrp-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/crrp/notification/worker/OutputNotificationConsumer.java
+++ b/src/crrp-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/crrp/notification/worker/OutputNotificationConsumer.java
@@ -1,0 +1,21 @@
+package ca.bc.gov.open.pssg.rsbc.crrp.notification.worker;
+
+import ca.bc.gov.open.pssg.rsbc.dps.notification.OutputNotificationMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OutputNotificationConsumer {
+
+    Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @RabbitListener(queues = Keys.CRRP_QUEUE_NAME)
+    public void receiveMessage(OutputNotificationMessage message) {
+
+        logger.info("received message for {}", message.getBusinessAreaCd());
+
+    }
+
+}

--- a/src/crrp-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/crrp/notification/worker/messaging/RabbitMqConfiguration.java
+++ b/src/crrp-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/crrp/notification/worker/messaging/RabbitMqConfiguration.java
@@ -1,0 +1,61 @@
+package ca.bc.gov.open.pssg.rsbc.crrp.notification.worker.messaging;
+
+import ca.bc.gov.open.pssg.rsbc.crrp.notification.worker.Keys;
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.boot.autoconfigure.amqp.RabbitProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMqConfiguration {
+
+    /**
+     * Configures the rabbitMq connection factory.
+     * @param rabbitProperties
+     * @return
+     */
+    @Bean
+    public ConnectionFactory connectionFactory(RabbitProperties rabbitProperties) {
+
+
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory(rabbitProperties.getHost(), rabbitProperties.getPort());
+
+        connectionFactory.setUsername(rabbitProperties.getUsername());
+        connectionFactory.setPassword(rabbitProperties.getPassword());
+
+        return connectionFactory;
+    }
+
+    @Bean
+    public RabbitAdmin rabbitAdmin(ConnectionFactory connectionFactory) {
+        return new RabbitAdmin(connectionFactory);
+    }
+
+    @Bean
+    public Queue crrpOutputNotificationQueue() {
+        return QueueBuilder
+                .durable(Keys.CRRP_QUEUE_NAME)
+                .build();
+    }
+
+    @Bean
+    public TopicExchange outputNotificationTopic() {
+        return new TopicExchange(Keys.OUTPUT_NOTIFICATION_VALUE, true, false);
+    }
+
+    @Bean
+    public Binding documentReadyBinding(Queue crrpOutputNotificationQueue, TopicExchange outputNotificationTopic) {
+        return BindingBuilder.bind(crrpOutputNotificationQueue).to(outputNotificationTopic)
+                .with(Keys.CRRP_VALUE);
+    }
+
+    @Bean
+    public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+}

--- a/src/crrp-notification-worker/src/main/resources/application.properties
+++ b/src/crrp-notification-worker/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 server.servlet.context-path=/crrpnotificationworker
+spring.rabbitmq.host: ${RABBITMQ_HOST:localhost}
+spring.rabbitmq.port: ${RABBITMQ_PORT:5672}
+spring.rabbitmq.username: ${RABBITMQ_USERNAME:guest}
+spring.rabbitmq.password: ${RABBITMQ_PASSWORD:guest}

--- a/src/crrp-notification-worker/src/test/java/ca/bc/gov/open/pssg/rsbc/crrp/notification/worker/OutputNotificationConsumerTest.java
+++ b/src/crrp-notification-worker/src/test/java/ca/bc/gov/open/pssg/rsbc/crrp/notification/worker/OutputNotificationConsumerTest.java
@@ -1,0 +1,29 @@
+package ca.bc.gov.open.pssg.rsbc.crrp.notification.worker;
+
+import ca.bc.gov.open.pssg.rsbc.dps.notification.OutputNotificationMessage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class OutputNotificationConsumerTest {
+
+    private OutputNotificationConsumer sut;
+
+    @BeforeAll
+    public void setUp() {
+        sut = new OutputNotificationConsumer();
+    }
+
+    @Test
+    public void withAMessageShouldProcess() {
+
+        Assertions.assertDoesNotThrow(() -> {
+            sut.receiveMessage(new OutputNotificationMessage(Keys.CRRP_QUEUE_NAME));
+        });
+
+    }
+
+
+}

--- a/src/libs/dpsnotification/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/notification/OutputNotificationMessage.java
+++ b/src/libs/dpsnotification/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/notification/OutputNotificationMessage.java
@@ -15,6 +15,8 @@ public class OutputNotificationMessage {
 
     private List<String> fileList =  new ArrayList<String>();
 
+    protected OutputNotificationMessage(){ }
+
     public OutputNotificationMessage(String businessAreaCd) {
         this.businessAreaCd = businessAreaCd;
     }


### PR DESCRIPTION
# Description

This PR includes the following proposed change:

- [DPSIM-201](https://justice.gov.bc.ca/jira/browse/DPSIM-201) - Add message consumer for crrp notification service

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

locally on docker

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **DPSIM-201**