### PR TITLE
Adding xsd for the vips metadata

### DIFF
--- a/src/vips-notification-worker/pom.xml
+++ b/src/vips-notification-worker/pom.xml
@@ -52,6 +52,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.9</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -89,6 +95,25 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>2.5.0</version>
+                <executions>
+                    <execution>
+                        <id>xjc</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <packageName>ca.bc.gov.open.pssg.rsbc.dps.vips.notification.worker.generated.models</packageName>
+                    <sources>
+                        <source>${project.basedir}/src/main/resources/kofax.vips.metadata.xsd</source>
+                    </sources>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 

--- a/src/vips-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/vips/notification/worker/OutputNotificationConsumer.java
+++ b/src/vips-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/vips/notification/worker/OutputNotificationConsumer.java
@@ -3,13 +3,14 @@ package ca.bc.gov.open.pssg.rsbc.vips.notification.worker;
 import ca.bc.gov.open.pssg.rsbc.dps.notification.OutputNotificationMessage;
 import ca.bc.gov.open.pssg.rsbc.dps.sftp.starter.SftpProperties;
 import ca.bc.gov.open.pssg.rsbc.dps.sftp.starter.SftpService;
+import ca.bc.gov.open.pssg.rsbc.vips.notification.worker.document.DocumentService;
+import com.migcomponents.migbase64.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 
 /**
@@ -22,30 +23,31 @@ public class OutputNotificationConsumer {
 
     public static final String METATADATA_EXTENSION = "xml";
     public static final String IMAGE_EXTENSION = "PDF";
+    private static final String MIME = "application";
+    private static final String MIME_SUBTYPE = "pdf";
+
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private final SftpService sftpService;
     private final SftpProperties sftpProperties;
+    private final DocumentService documentService;
 
-    public OutputNotificationConsumer(SftpService sftpService, SftpProperties sftpProperties) {
+    public OutputNotificationConsumer(SftpService sftpService, SftpProperties sftpProperties,
+                                      DocumentService documentService) {
         this.sftpService = sftpService;
         this.sftpProperties = sftpProperties;
+        this.documentService = documentService;
     }
 
     @RabbitListener(queues = Keys.VIPS_QUEUE_NAME)
     public void receiveMessage(OutputNotificationMessage message) {
 
         logger.info("received message for {}", message.getBusinessAreaCd());
-        ByteArrayInputStream metadataBin = sftpService.getContent(buildFileName(message.getFileId(), METATADATA_EXTENSION));
+        String metadata = getBase64Metadata(message.getFileId());
         logger.info("successfully downloaded file [{}]", buildFileName(message.getFileId(), METATADATA_EXTENSION));
 
-        int n = metadataBin.available();
-        byte[] bytes = new byte[n];
-        metadataBin.read(bytes, 0, n);
-        logger.info(new String(bytes, StandardCharsets.UTF_8));
-
         logger.info("received message for {}", message.getBusinessAreaCd());
-        ByteArrayInputStream imageBin = sftpService.getContent(buildFileName(message.getFileId(), METATADATA_EXTENSION));
+        byte[] image = getImage(message.getFileId());
         logger.info("successfully downloaded file [{}]", buildFileName(message.getFileId(), IMAGE_EXTENSION));
 
     }
@@ -53,5 +55,29 @@ public class OutputNotificationConsumer {
     private String buildFileName(String fileId, String extension) {
         return MessageFormat.format("{0}/release/{1}.{2}",sftpProperties.getRemoteLocation(), fileId, extension);
     }
+
+
+    private String getBase64Metadata(String fileId) {
+        ByteArrayInputStream metadataBin = sftpService.getContent(buildFileName(fileId, METATADATA_EXTENSION));
+
+        int n = metadataBin.available();
+        byte[] bytes = new byte[n];
+        metadataBin.read(bytes, 0, n);
+
+        return Base64.encodeToString(bytes, false);
+    }
+
+    private byte[] getImage(String fileId) {
+
+        ByteArrayInputStream imageBin = sftpService.getContent(buildFileName(fileId, IMAGE_EXTENSION));
+
+        int n = imageBin.available();
+        byte[] bytes = new byte[n];
+        imageBin.read(bytes, 0, n);
+
+        return bytes;
+
+    }
+
 
 }

--- a/src/vips-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/vips/notification/worker/configuration/OrdsVipsProperties.java
+++ b/src/vips-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/vips/notification/worker/configuration/OrdsVipsProperties.java
@@ -9,7 +9,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author shaunmillargov
  *
  */
-@ConfigurationProperties(prefix = "vips-notification-worker.service.ords.vips.client")
+@ConfigurationProperties(prefix = "ords.vips.client")
 public class OrdsVipsProperties {
 
     private String basePath;

--- a/src/vips-notification-worker/src/main/resources/application.properties
+++ b/src/vips-notification-worker/src/main/resources/application.properties
@@ -3,9 +3,9 @@ spring.rabbitmq.host: ${RABBITMQ_HOST:localhost}
 spring.rabbitmq.port: ${RABBITMQ_PORT:5672}
 spring.rabbitmq.username: ${RABBITMQ_USERNAME:guest}
 spring.rabbitmq.password: ${RABBITMQ_PASSWORD:guest}
-ords.figcr.client.base-path=${FIGCR_BASE_PATH}
-ords.figcr.client.username=${FIGCR_USERNAME}
-ords.figcr.client.password=${FIGCR_PASSWORD}
+ords.vips.client.base-path=${ORDS_BASE_PATH}
+ords.vips.client.username=${ORDS_SERNAME}
+ords.vips.client.password=${ORDS_PASSWORD}
 
 dps.sftp.host=${DPS_SFTP_HOST:localhost}
 dps.sftp.port=${DPS_SFTP_PORT:22}

--- a/src/vips-notification-worker/src/main/resources/kofax.vips.metadata.xsd
+++ b/src/vips-notification-worker/src/main/resources/kofax.vips.metadata.xsd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:complexType name="KofaxOutputMetadata">
+        <xsd:sequence>
+            <xsd:element name="Data" nillable="true">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="BatchData" nillable="true">
+                            <xsd:complexType>
+                                <xsd:sequence>
+                                    <xsd:element name="BatchId" nillable="true" type="xsd:string"/>
+                                    <xsd:element name="FaxReceivedDate" nillable="true" type="xsd:string"/>
+                                    <xsd:element name="ImportDate" nillable="true" type="xsd:string"/>
+                                    <xsd:element name="ImportID" nillable="true" type="xsd:string"/>
+                                    <xsd:element name="OriginatingNumber" nillable="true" type="xsd:string"/>
+                                    <xsd:element name="ProgramType" nillable="true" type="xsd:string"/>
+                                </xsd:sequence>
+                            </xsd:complexType>
+                        </xsd:element>
+                        <xsd:element name="DocumentData" nillable="true">
+                            <xsd:complexType>
+                                <xsd:sequence>
+                                    <xsd:element name="externalFile" nillable="true" type="xsd:string"/>
+                                    <xsd:element name="adpNumber" nillable="true" type="xsd:string"/>
+                                    <xsd:element name="documentPages" nillable="true" type="xsd:string"/>
+                                    <xsd:element name="dType" nillable="true" type="xsd:string"/>
+                                    <xsd:element name="irpNumber" nillable="true" type="xsd:string"/>
+                                    <xsd:element name="policeFileNo" nillable="true" type="xsd:string"/>
+                                    <xsd:element name="ulNumber" nillable="true" type="xsd:string"/>
+                                    <xsd:element name="validationUser" nillable="true" type="xsd:string"/>
+                                    <xsd:element name="vinoiNumber" nillable="true" type="xsd:string"/>
+                                </xsd:sequence>
+                            </xsd:complexType>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:schema>

--- a/src/vips-notification-worker/src/test/java/ca/bc/gov/open/pssg/rsbc/vips/notification/worker/OutputNotificationConsumerTest.java
+++ b/src/vips-notification-worker/src/test/java/ca/bc/gov/open/pssg/rsbc/vips/notification/worker/OutputNotificationConsumerTest.java
@@ -3,6 +3,7 @@ package ca.bc.gov.open.pssg.rsbc.vips.notification.worker;
 import ca.bc.gov.open.pssg.rsbc.dps.notification.OutputNotificationMessage;
 import ca.bc.gov.open.pssg.rsbc.dps.sftp.starter.SftpProperties;
 import ca.bc.gov.open.pssg.rsbc.dps.sftp.starter.SftpService;
+import ca.bc.gov.open.pssg.rsbc.vips.notification.worker.document.DocumentService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,9 @@ public class OutputNotificationConsumerTest {
     @Mock
     private SftpService sftpServiceMock;
 
+    @Mock
+    private DocumentService documentServiceMock;
+
     private ByteArrayInputStream fakeContent() {
         String content = "fake content";
         return new ByteArrayInputStream(content.getBytes());
@@ -40,7 +44,7 @@ public class OutputNotificationConsumerTest {
         sftpProperties.setRemoteLocation(REMOTE_LOCATION);
 
 
-        sut = new OutputNotificationConsumer(sftpServiceMock, sftpProperties);
+        sut = new OutputNotificationConsumer(sftpServiceMock, sftpProperties, documentServiceMock);
     }
 
     @Test


### PR DESCRIPTION
# Description

This PR includes the following proposed changes:

- add the xsd for the metadata
- add methods to retrieve both files.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes