### PR TITLE
Configure splunk for validation services

### DIFF
--- a/src/dps-validation-service/pom.xml
+++ b/src/dps-validation-service/pom.xml
@@ -86,9 +86,15 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-access</artifactId>
         </dependency>
 
         <dependency>
@@ -212,6 +218,30 @@
 
 
     </dependencies>
+
+    <profiles>
+        <profile>
+
+            <id>openshift</id>
+
+            <repositories>
+                <repository>
+                    <id>splunk-artifactory</id>
+                    <name>Splunk Releases</name>
+                    <url>http://splunk.jfrog.io/splunk/ext-releases-local</url>
+                </repository>
+            </repositories>
+
+            <dependencies>
+                <dependency>
+                    <groupId>com.splunk.logging</groupId>
+                    <artifactId>splunk-library-javalogging</artifactId>
+                    <version>1.7.1</version>
+                </dependency>
+            </dependencies>
+
+        </profile>
+    </profiles>
 
     <build>
         <plugins>

--- a/src/dps-validation-service/src/main/resources/application-splunk.properties
+++ b/src/dps-validation-service/src/main/resources/application-splunk.properties
@@ -1,0 +1,2 @@
+# configure to use splunk logback configuration
+logging.config:classpath:logback-splunk.xml

--- a/src/dps-validation-service/src/main/resources/application.properties
+++ b/src/dps-validation-service/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.servlet.context-path=/dpsvalidationservice
-server.port=8081
+
 # Swagger Ui
 dpsvalidation.service.api.version=0.0.1
 dpsvalidation.service.swagger.enabled=true

--- a/src/dps-validation-service/src/main/resources/logback-access.xml
+++ b/src/dps-validation-service/src/main/resources/logback-access.xml
@@ -1,0 +1,30 @@
+<configuration>
+
+    <appender name="STDOUT"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.access.PatternLayout">
+            <Pattern>combined</Pattern>
+        </layout>
+    </appender>
+
+    <appender-ref ref="STDOUT" />
+
+    <springProfile name="splunk">
+
+        <appender name="http" class="com.splunk.logging.HttpEventCollectorLogbackAppender">
+            <url>${SPLUNK_URL}</url>
+            <token>${SPLUNK_TOKEN}</token>
+            <source>dps-validation-service</source>
+            <sourcetype>dps-access-logs</sourcetype>
+            <middleware>HttpEventCollectorUnitTestMiddleware</middleware>
+            <disableCertificateValidation>true</disableCertificateValidation>
+            <layout class="ch.qos.logback.access.PatternLayout">
+                <pattern>combined</pattern>
+            </layout>
+        </appender>
+
+        <appender-ref ref="http" />
+
+    </springProfile>
+
+</configuration>

--- a/src/dps-validation-service/src/main/resources/logback-splunk.xml
+++ b/src/dps-validation-service/src/main/resources/logback-splunk.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    ​
+    <!-- You can override this to have a custom pattern -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"/>
+
+    <appender name="http" class="com.splunk.logging.HttpEventCollectorLogbackAppender">
+        <url>${SPLUNK_URL}</url>
+        <token>${SPLUNK_TOKEN}</token>
+        <source>dps-validation-service</source>
+        <sourcetype>dps-logs</sourcetype>
+        <middleware>HttpEventCollectorUnitTestMiddleware</middleware>
+        <disableCertificateValidation>true</disableCertificateValidation>
+        <batch_size_count>1</batch_size_count>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%msg</pattern>
+        </layout>
+    </appender>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="http"/>
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/src/figaro-validation-service/pom.xml
+++ b/src/figaro-validation-service/pom.xml
@@ -88,6 +88,10 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-access</artifactId>
+        </dependency>
 
         <!-- HTTP client: jersey-client -->
         <dependency>

--- a/src/figaro-validation-service/src/main/resources/application-splunk.properties
+++ b/src/figaro-validation-service/src/main/resources/application-splunk.properties
@@ -1,0 +1,2 @@
+# configure to use splunk logback configuration
+logging.config:classpath:logback-splunk.xml


### PR DESCRIPTION
# Description

This PR includes the following proposed changes:

- Configure Figaro validation service and dps validation service to push access logs to splunk
- Configure dps validation service default port to 8080

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

No Test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
