### PR TITLE
PL queue message handling

### DIFF
--- a/src/dps-email-poller/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailpoller/email/api/DpsEmailController.java
+++ b/src/dps-email-poller/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailpoller/email/api/DpsEmailController.java
@@ -44,4 +44,20 @@ public class DpsEmailController {
             return new ResponseEntity<>(DpsEmailResponse.Error(ex.getMessage()), HttpStatus.BAD_REQUEST);
         }
     }
+
+    @PutMapping(value = "/email/{id}/error", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successful operation", response = DpsEmailResponse.class),
+            @ApiResponse(code = 400, message = "Bad Request", response = DpsEmailResponse.class)
+    })
+    @ApiOperation(value = "Mark email as having an error in processing", tags = {"DpsEmailProcessing"})
+    public ResponseEntity<DpsEmailResponse> ProcessFailed(@PathVariable String id, @RequestBody DpsEmailProcessedRequest dpsEmailProcessedRequest) {
+        try {
+            emailService.moveToErrorFolder(new String(Base64.getDecoder().decode(id)));
+            logger.info("message successfully moved to error folder, id: [{}]", dpsEmailProcessedRequest.getCorrelationId());
+            return new ResponseEntity<>(DpsEmailResponse.Success(), HttpStatus.OK);
+        } catch (DpsEmailException ex) {
+            return new ResponseEntity<>(DpsEmailResponse.Error(ex.getMessage()), HttpStatus.BAD_REQUEST);
+        }
+    }
 }

--- a/src/dps-email-poller/src/test/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailpoller/email/api/DpsEmailControllerTest.java
+++ b/src/dps-email-poller/src/test/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailpoller/email/api/DpsEmailControllerTest.java
@@ -35,12 +35,46 @@ public class DpsEmailControllerTest {
         Mockito.when(emailServiceMock.moveToProcessedFolder(Mockito.eq(CASE_2))).thenThrow(new DpsEmailException(
                 EMAIL_EXCEPTION));
 
+        Mockito.when(emailServiceMock.moveToErrorFolder(Mockito.eq(CASE_1))).thenReturn(emailMessageMock);
+        Mockito.when(emailServiceMock.moveToErrorFolder(Mockito.eq(CASE_2))).thenThrow(new DpsEmailException(
+                EMAIL_EXCEPTION));
+
         sut = new DpsEmailController(emailServiceMock);
     }
 
-    @DisplayName("success - with email moved should return acknowledge")
+    @DisplayName("success - with processed email moved should return acknowledge")
     @Test
-    public void withEmailMovedShouldReturnSuccess() {
+    public void withProcessedEmailMovedShouldReturnSuccess() {
+
+        DpsEmailProcessedRequest dpsEmailProcessedRequest = new DpsEmailProcessedRequest();
+        dpsEmailProcessedRequest.setCorrelationId("test");
+
+        ResponseEntity<DpsEmailResponse> response = sut.ProcessFailed(new DpsMetadata.Builder().withEmailId(CASE_1).build().getBase64EmailId(),
+                dpsEmailProcessedRequest);
+
+        Assertions.assertEquals(HttpStatus.OK, response.getStatusCode());
+        Assertions.assertTrue(response.getBody().isAcknowledge());
+
+    }
+
+    @DisplayName("success - with processed email not moved should return error message")
+    @Test
+    public void withProcessedEmailNotMovedShouldReturnError() {
+
+        DpsEmailProcessedRequest dpsEmailProcessedRequest = new DpsEmailProcessedRequest();
+        dpsEmailProcessedRequest.setCorrelationId("test");
+
+        ResponseEntity<DpsEmailResponse> response = sut.ProcessFailed(new DpsMetadata.Builder().withEmailId(CASE_2).build().getBase64EmailId(), dpsEmailProcessedRequest);
+
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assertions.assertFalse(response.getBody().isAcknowledge());
+        Assertions.assertEquals(EMAIL_EXCEPTION, response.getBody().getMessage());
+
+    }
+
+    @DisplayName("success - with failed email moved should return acknowledge")
+    @Test
+    public void withFailedEmailMovedShouldReturnSuccess() {
 
         DpsEmailProcessedRequest dpsEmailProcessedRequest = new DpsEmailProcessedRequest();
         dpsEmailProcessedRequest.setCorrelationId("test");
@@ -53,9 +87,9 @@ public class DpsEmailControllerTest {
 
     }
 
-    @DisplayName("success - with error should return error message")
+    @DisplayName("success - with failed email not moved should return error message")
     @Test
-    public void withEmailNotMovedShouldReturnError() {
+    public void withFailedEmailNotMovedShouldReturnError() {
 
         DpsEmailProcessedRequest dpsEmailProcessedRequest = new DpsEmailProcessedRequest();
         dpsEmailProcessedRequest.setCorrelationId("test");

--- a/src/dps-email-poller/src/test/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailpoller/email/api/DpsEmailControllerTest.java
+++ b/src/dps-email-poller/src/test/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailpoller/email/api/DpsEmailControllerTest.java
@@ -42,9 +42,9 @@ public class DpsEmailControllerTest {
         sut = new DpsEmailController(emailServiceMock);
     }
 
-    @DisplayName("success - with processed email moved should return acknowledge")
+    @DisplayName("success - with failed email moved should return acknowledge")
     @Test
-    public void withProcessedEmailMovedShouldReturnSuccess() {
+    public void withFailedEmailMovedShouldReturnSuccess() {
 
         DpsEmailProcessedRequest dpsEmailProcessedRequest = new DpsEmailProcessedRequest();
         dpsEmailProcessedRequest.setCorrelationId("test");
@@ -57,9 +57,9 @@ public class DpsEmailControllerTest {
 
     }
 
-    @DisplayName("success - with processed email not moved should return error message")
+    @DisplayName("success - with failed email not moved should return error message")
     @Test
-    public void withProcessedEmailNotMovedShouldReturnError() {
+    public void withFailedEmailNotMovedShouldReturnError() {
 
         DpsEmailProcessedRequest dpsEmailProcessedRequest = new DpsEmailProcessedRequest();
         dpsEmailProcessedRequest.setCorrelationId("test");
@@ -72,9 +72,9 @@ public class DpsEmailControllerTest {
 
     }
 
-    @DisplayName("success - with failed email moved should return acknowledge")
+    @DisplayName("success - with processed email moved should return acknowledge")
     @Test
-    public void withFailedEmailMovedShouldReturnSuccess() {
+    public void withProcessedEmailMovedShouldReturnSuccess() {
 
         DpsEmailProcessedRequest dpsEmailProcessedRequest = new DpsEmailProcessedRequest();
         dpsEmailProcessedRequest.setCorrelationId("test");
@@ -87,9 +87,9 @@ public class DpsEmailControllerTest {
 
     }
 
-    @DisplayName("success - with failed email not moved should return error message")
+    @DisplayName("success - with processed email not moved should return error message")
     @Test
-    public void withFailedEmailNotMovedShouldReturnError() {
+    public void withProcessedEmailNotMovedShouldReturnError() {
 
         DpsEmailProcessedRequest dpsEmailProcessedRequest = new DpsEmailProcessedRequest();
         dpsEmailProcessedRequest.setCorrelationId("test");

--- a/src/dps-email-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailworker/DpsEmailConsumer.java
+++ b/src/dps-email-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailworker/DpsEmailConsumer.java
@@ -55,11 +55,7 @@ public class DpsEmailConsumer {
         ImportSession session = importSessionService.generateImportSession(message);
         if(!session.getBatchName().isPresent()) throw new DpsEmailWorkerException("batch name is required.");
 
-
-
         try {
-
-
 
             logger.debug("attempting to get message meta data [{}]", message);
             DpsFileInfo dpsFileInfo = message.getFileInfo();

--- a/src/dps-email-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailworker/Keys.java
+++ b/src/dps-email-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailworker/Keys.java
@@ -14,6 +14,11 @@ public class Keys {
     public static final String EMAIL_QUEUE_NAME = EMAIL_VALUE + ".emailmessage.Q";
 
     /**
+     * DO NOT CHANGE - The name of the DPS email queue
+     */
+    public static final String PARKING_QUEUE_NAME = EMAIL_VALUE + ".emailmessage.PL";
+
+    /**
      * DO NOT CHANGE - The default output notification value.
      */
     public static final String OUTPUT_NOTIFICATION_VALUE = "emailMessage";

--- a/src/dps-email-worker/src/test/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailworker/DpsEmailConsumerTest.java
+++ b/src/dps-email-worker/src/test/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailworker/DpsEmailConsumerTest.java
@@ -25,6 +25,7 @@ public class DpsEmailConsumerTest {
 
     private static final String CASE_1 = "case1";
     private static final String CASE_2 = "case2";
+    private static final String CASE_3 = "case3";
     private static final String EMAIL_EXCEPTION = "email exception";
     private static final String CORRELATION = "correlation";
     private static final String FAKE_CONTENT = "fake content";
@@ -54,6 +55,9 @@ public class DpsEmailConsumerTest {
     @Mock
     private DpsEmailProcessedResponse dpsEmailProcessedResponseMock;
 
+    @Mock
+    private DpsEmailProcessedResponse dpsEmailFailedResponseMock;
+
     @BeforeAll
     public void setUp() throws Exception {
 
@@ -73,10 +77,15 @@ public class DpsEmailConsumerTest {
         Mockito.when(storageServiceMock.get(Mockito.eq(CASE_1))).thenReturn(FAKE_CONTENT.getBytes());
         Mockito.doNothing().when(storageServiceMock).delete(Mockito.eq(CASE_1));
 
+        Mockito.when(storageServiceMock.get(Mockito.eq(CASE_3))).thenReturn(FAKE_CONTENT.getBytes());
+        Mockito.doNothing().when(storageServiceMock).delete(Mockito.eq(CASE_3));
+
         Mockito.when(dpsMetadataMock.getFileInfo()).thenReturn(dpsFileInfoMock);
         Mockito.when(dpsFileInfoMock.getId()).thenReturn("id");
 
         Mockito.when(dpsEmailServiceMock.dpsEmailProcessed(Mockito.eq(CASE_1), Mockito.anyString())).thenReturn(dpsEmailProcessedResponseMock);
+        Mockito.when(dpsEmailServiceMock.dpsEmailFailed(Mockito.anyString(), Mockito.anyString())).thenReturn(dpsEmailFailedResponseMock);
+        Mockito.when(dpsEmailFailedResponseMock.isAcknowledge()).thenReturn(true).thenReturn(true).thenReturn(false).thenReturn(false);
 
         Mockito.when(importSessionService.generateImportSession(Mockito.any(DpsMetadata.class))).thenReturn(fakeSession);
         Mockito.when(importSessionService.convertToXmlBytes(Mockito.any(ImportSession.class))).thenReturn(("<test" +
@@ -123,5 +132,24 @@ public class DpsEmailConsumerTest {
 
     }
 
+    @DisplayName("success - receiveParkedMessage should not throw")
+    @Test
+    public void withEmailFailedShouldReturnSuccess() {
+
+        Assertions.assertDoesNotThrow(() -> {
+            sut.receiveParkedMessage(new DpsMetadata.Builder().withApplicationID(CASE_3).withFileInfo(new DpsFileInfo(CASE_3, FILE_NAME, "String")).withEmailId("a@a.com").build());
+        });
+
+        Mockito.verify(storageServiceMock, Mockito.times(1))
+                .delete(Mockito.eq(CASE_3));
+
+        // Second call to receiveParkedMessage should not have the isAcknowledge() == true, so should not delete
+        Assertions.assertDoesNotThrow(() -> {
+            sut.receiveParkedMessage(new DpsMetadata.Builder().withApplicationID(CASE_3).withFileInfo(new DpsFileInfo(CASE_3, FILE_NAME, "String")).withEmailId("a@a.com").build());
+        });
+
+        Mockito.verify(storageServiceMock, Mockito.times(1))
+                .delete(Mockito.eq(CASE_3));
+    }
 }
 

--- a/src/dps-email-worker/src/test/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailworker/DpsEmailConsumerTest.java
+++ b/src/dps-email-worker/src/test/java/ca/bc/gov/open/pssg/rsbc/dps/dpsemailworker/DpsEmailConsumerTest.java
@@ -85,7 +85,7 @@ public class DpsEmailConsumerTest {
 
         Mockito.when(dpsEmailServiceMock.dpsEmailProcessed(Mockito.eq(CASE_1), Mockito.anyString())).thenReturn(dpsEmailProcessedResponseMock);
         Mockito.when(dpsEmailServiceMock.dpsEmailFailed(Mockito.anyString(), Mockito.anyString())).thenReturn(dpsEmailFailedResponseMock);
-        Mockito.when(dpsEmailFailedResponseMock.isAcknowledge()).thenReturn(true).thenReturn(true).thenReturn(false).thenReturn(false);
+        Mockito.when(dpsEmailFailedResponseMock.isAcknowledge()).thenReturn(true).thenReturn(false);
 
         Mockito.when(importSessionService.generateImportSession(Mockito.any(DpsMetadata.class))).thenReturn(fakeSession);
         Mockito.when(importSessionService.convertToXmlBytes(Mockito.any(ImportSession.class))).thenReturn(("<test" +

--- a/src/libs/dps-commons/src/main/java/ca/bc/gov/open/pssg/rsbc/models/DpsMetadata.java
+++ b/src/libs/dps-commons/src/main/java/ca/bc/gov/open/pssg/rsbc/models/DpsMetadata.java
@@ -203,4 +203,12 @@ public class DpsMetadata {
         return fileInfo;
     }
 
+    @Override
+    public String toString() {
+        return " [" +
+                "transactionId=" + transactionId +
+                ", emailId='" + emailId + '\'' +
+                ", from='" + from + '\'' +
+                "] ";
+    }
 }

--- a/src/libs/dps-email-client/dpsemailclient.yaml
+++ b/src/libs/dps-email-client/dpsemailclient.yaml
@@ -6,31 +6,70 @@ info:
 host: 'localhost:8082'
 basePath: /dpsemailpoller
 tags:
-- name: dps-email-controller
-  description: Dps Email Controller
+  - name: dps-email-controller
+    description: Dps Email Controller
 paths:
+  '/email/{id}/error':
+    put:
+      tags:
+        - DpsEmailProcessing
+      summary: Mark email as having an error in processing
+      operationId: ProcessFailedUsingPUT
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: id
+          required: true
+          type: string
+        - in: body
+          name: dpsEmailProcessedRequest
+          description: dpsEmailProcessedRequest
+          required: true
+          schema:
+            $ref: '#/definitions/DpsEmailProcessedRequest'
+      responses:
+        '200':
+          description: Successful operation
+          schema:
+            $ref: '#/definitions/DpsEmailResponse'
+        '201':
+          description: Created
+        '400':
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/DpsEmailResponse'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
   '/email/{id}/processed':
     put:
       tags:
-      - DpsEmailProcessing
+        - DpsEmailProcessing
       summary: Mark email as processed
       operationId: ProcessedUsingPUT
       consumes:
-      - application/json
+        - application/json
       produces:
-      - application/json
+        - application/json
       parameters:
-      - name: id
-        in: path
-        description: id
-        required: true
-        type: string
-      - in: body
-        name: dpsEmailProcessedRequest
-        description: dpsEmailProcessedRequest
-        required: true
-        schema:
-          $ref: '#/definitions/DpsEmailProcessedRequest'
+        - name: id
+          in: path
+          description: id
+          required: true
+          type: string
+        - in: body
+          name: dpsEmailProcessedRequest
+          description: dpsEmailProcessedRequest
+          required: true
+          schema:
+            $ref: '#/definitions/DpsEmailProcessedRequest'
       responses:
         '200':
           description: Successful operation

--- a/src/libs/dps-email-client/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/email/client/DpsEmailService.java
+++ b/src/libs/dps-email-client/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/email/client/DpsEmailService.java
@@ -8,5 +8,5 @@ package ca.bc.gov.open.pssg.rsbc.dps.email.client;
 public interface DpsEmailService {
 
      DpsEmailProcessedResponse dpsEmailProcessed(String id, String correlationId);
-
+     DpsEmailProcessedResponse dpsEmailFailed(String id, String correlationId);
 }

--- a/src/libs/dps-email-client/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/email/client/DpsEmailServiceImpl.java
+++ b/src/libs/dps-email-client/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/email/client/DpsEmailServiceImpl.java
@@ -37,4 +37,21 @@ public class DpsEmailServiceImpl implements DpsEmailService {
             return DpsEmailProcessedResponse.errorResponse(ex.getMessage());
         }
     }
+
+    @Override
+    public DpsEmailProcessedResponse dpsEmailFailed(String id, String correlationId) {
+
+        try {
+
+            DpsEmailProcessedRequest request = new DpsEmailProcessedRequest();
+            request.setCorrelationId("");
+
+            DpsEmailResponse response = this.dpsEmailProcessingApi.processFailedUsingPUT(id, request);
+            return DpsEmailProcessedResponse.successResponse(response.getAcknowledge(), response.getMessage());
+
+        } catch (ApiException ex) {
+            logger.error("Exception caught in dpsEmailProcessed", ex);
+            return DpsEmailProcessedResponse.errorResponse(ex.getMessage());
+        }
+    }
 }

--- a/src/libs/dps-messaging-starter/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/messaging/starter/DpsMessagePostProcessor.java
+++ b/src/libs/dps-messaging-starter/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/messaging/starter/DpsMessagePostProcessor.java
@@ -36,6 +36,11 @@ public class DpsMessagePostProcessor implements MessagePostProcessor {
 
         if(message.getMessageProperties() == null) return message;
 
+        // We do not want to run this postProcess on message coming from the ".PL" queue
+        // as the purpose of this postProcess is to move them there when we've failed to
+        // process them too many times.
+        if(message.getMessageProperties().getConsumerQueue().endsWith(".PL")) return message;
+
         List<Map<String, ?>> xDeathCollection = message.getMessageProperties().getXDeathHeader();
 
         if(xDeathCollection == null || xDeathCollection.isEmpty()) return message;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Added a rest call to the email poller app for failed emails
- Added functionality to email worker app to check the PL queue and process the messages in there as failed, including telling the poller app to move the email to ErrHold and cleaning up the redis cache.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally to verify functionality
All unit tests run locally.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
