### PR TITLE
changed call to api to send filename only

### DIFF
--- a/src/spd-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/spd/notification/worker/OutputNotificationConsumer.java
+++ b/src/spd-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/spd/notification/worker/OutputNotificationConsumer.java
@@ -77,7 +77,7 @@ public class OutputNotificationConsumer {
 
             logger.debug("attempting to store spd document [{}]", fileInfo.getMetaDataReleaseFileName());
             DpsDocumentRequestBody documentRequestBody = new DpsDocumentRequestBody(sftpProperties.getHost(),
-                    fileInfo.getImageReleaseFileName());
+                    fileInfo.getFileId());
             DpsDocumentResponse documentResponse = documentService.storeDocument(documentRequestBody);
             logger.info("successfully stored file [{}], id [()]", fileInfo.getMetaDataReleaseFileName());
 

--- a/src/spd-notification-worker/src/test/java/ca/bc/gov/open/pssg/rsbc/spd/notification/worker/OutputNotificationConsumerTest.java
+++ b/src/spd-notification-worker/src/test/java/ca/bc/gov/open/pssg/rsbc/spd/notification/worker/OutputNotificationConsumerTest.java
@@ -134,7 +134,7 @@ public class OutputNotificationConsumerTest {
         Mockito
                 .doReturn(DpsDocumentResponse.successResponse(DOCUMENT_GUID, STATUS_CODE, STATUS_MESSAGE))
                 .when(documentServiceMock)
-                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(getFileInfo(CASE_1).getImageReleaseFileName())));
+                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(CASE_1)));
 
         Mockito
                 .doReturn(DpsDataIntoFigaroResponse.successResponse(STATUS_CODE, STATUS_MESSAGE))
@@ -151,7 +151,7 @@ public class OutputNotificationConsumerTest {
         Mockito
                 .doReturn(DpsDocumentResponse.errorResponse(STATUS_CODE_ERROR))
                 .when(documentServiceMock)
-                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(getFileInfo(CASE_1API_ERROR_CODE).getImageReleaseFileName())));
+                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(CASE_1API_ERROR_CODE)));
 
         // dpsDataIntoFigaro api ERROR
 
@@ -163,7 +163,7 @@ public class OutputNotificationConsumerTest {
         Mockito
                 .doReturn(DpsDocumentResponse.successResponse(CASE_2API_ERROR_CODE, STATUS_CODE, STATUS_MESSAGE))
                 .when(documentServiceMock)
-                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(getFileInfo(CASE_2API_ERROR_CODE).getImageReleaseFileName())));
+                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(CASE_2API_ERROR_CODE)));
 
         Mockito
                 .doReturn(DpsDataIntoFigaroResponse.errorResponse(STATUS_CODE_ERROR))
@@ -204,7 +204,7 @@ public class OutputNotificationConsumerTest {
 
         Mockito
                 .verify(documentServiceMock, Mockito.times(1))
-                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(getFileInfo(CASE_1).getImageReleaseFileName())));
+                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(CASE_1)));
 
         Mockito
                 .verify(documentServiceMock, Mockito.times(1))
@@ -226,7 +226,7 @@ public class OutputNotificationConsumerTest {
 
         Mockito
                 .verify(documentServiceMock, Mockito.never())
-                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(getFileInfo(CASE_SFTP_EXCEPTION).getImageReleaseFileName())));
+                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(CASE_SFTP_EXCEPTION)));
 
         Mockito
                 .verify(documentServiceMock, Mockito.never())
@@ -279,7 +279,7 @@ public class OutputNotificationConsumerTest {
 
         Mockito
                 .verify(documentServiceMock, Mockito.times(1))
-                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(getFileInfo(CASE_1API_ERROR_CODE).getImageReleaseFileName())));
+                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(CASE_1API_ERROR_CODE)));
 
         Mockito
                 .verify(documentServiceMock, Mockito.never())
@@ -302,7 +302,7 @@ public class OutputNotificationConsumerTest {
 
         Mockito
                 .verify(documentServiceMock, Mockito.times(1))
-                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(getFileInfo(CASE_2API_ERROR_CODE).getImageReleaseFileName())));
+                .storeDocument(ArgumentMatchers.argThat(x -> x.getFileName().equals(CASE_2API_ERROR_CODE)));
 
         Mockito
                 .verify(documentServiceMock, Mockito.times(1))

--- a/src/vips-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/vips/notification/worker/OutputNotificationConsumer.java
+++ b/src/vips-notification-worker/src/main/java/ca/bc/gov/open/pssg/rsbc/vips/notification/worker/OutputNotificationConsumer.java
@@ -151,7 +151,7 @@ public class OutputNotificationConsumer {
                 .withCorrelationId(message.getFileId())
                 .withApplicationName(Keys.APP_NAME)
                 .withComponent("Notification Worker")
-                .withMessage("Data successfully transfered to FIGARO")
+                .withMessage("Data successfully transfered to VIPS")
                 .withType("VIPS NOTIFICATION WORKER SUCCESS")
                 .buildSuccess();
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- fix call to figaro db api by using the filename only

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Running unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
