### PR TITLE
8 Digit Drivers Licenses

### DIFF
--- a/src/dps-validation-service/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/dpsvalidationservice/dfcms/ValidationController.java
+++ b/src/dps-validation-service/src/main/java/ca/bc/gov/open/pssg/rsbc/dps/dpsvalidationservice/dfcms/ValidationController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ValidationController {
     private static final Logger logger = LogManager.getLogger(ValidationController.class);
-    public static final String DL_REGEX = "[0-9]{7}";
+    public static final String DL_REGEX = "[0-9]{7,8}";
     public static final String SURCODE_REGEX = "^[a-zA-Z&-.]{0,3}";
 
     private final CaseService caseService;


### PR DESCRIPTION
Expanded the drivers license REGEX expression to allow for 8 digit drivers licenses as well as 7.