### PR TITLE
Eight Digit License

### DIFF
--- a/src/dps-validation-service/src/main/resources/application.properties
+++ b/src/dps-validation-service/src/main/resources/application.properties
@@ -10,5 +10,8 @@ dpsvalidation.service.ords.dfcms.client.base-path=${DFCMS_BASE_PATH}
 dpsvalidation.service.ords.dfcms.client.username=${DFCMS_USERNAME}
 dpsvalidation.service.ords.dfcms.client.password=${DFCMS_PASSWORD}
 
+# Feature flag for eight digit driver's licenses
+dpsvalidation.service.validation.eight-digit-license=${DFCMS_EIGHT_DIGIT_LICENSE}
+
 # Spring boot actuator health
 management.endpoint.health.show-details=ALWAYS


### PR DESCRIPTION
Modifying the validation service to use a feature flag to determine if it should be validating 7 or 8 digit licenses.  If 7, uses the license as given in params, if 8 - checks the license length and if it is 7 prepends a 0 to it.