### PR TITLE
in trivy step : changing image_tag from dev,1 to latest because of reusable workflow just accept 1 parameter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
     with:
       imagestream_name: ${{ github.event.inputs.app_name }}
 #      image_tag: "${{ needs.app-version.outputs.app-version }}"
-      image_tag: "dev,1"
+      image_tag: "latest"
     secrets:
       openshift_external_repository: "${{ secrets.OPENSHIFT_EXTERNAL_REPOSITORY_SILVER }}"
       openshift_namespace: "${{ secrets.OPENSHIFT_LICENSE_PLATE_SILVER }}-tools"


### PR DESCRIPTION
in trivy step : changing image_tag from dev,1 to latest because of reusable workflow just accept 1 parameter